### PR TITLE
fix(crawler): check 20 pages since Steam is flaky

### DIFF
--- a/workspaces/crawler/src/routines/1-discover.ts
+++ b/workspaces/crawler/src/routines/1-discover.ts
@@ -16,7 +16,7 @@ import scrapeIt from 'scrape-it'
 * 3. Note steam sorting algorithm - it works but it's not perfect!
 */
 const TYPE = 'mostrecent'
-const MAX_PAGES = 10  // MAX is 1670 due how steam workshop works.
+const MAX_PAGES = 20  // MAX is 1670 due how steam workshop works.
 const SKIP_PAGES = 0
 
 


### PR DESCRIPTION
Crawler is checking 10 pages (~300 blueprints) of most recent blueprints for new ones every 3 hours. Usually that's few pages full of new IDs, but always there's at least that one new blueprint being at 7th page or so, because Steam ordering is totally not exact.

It turns out there usually was also a blueprint beyond the 10th, which got skipped. So I bumped crawler to check 20 pages in order not to skip any. Hopefully that's enough.

Also re-rediscovered all 1670 most recent pages to catch already skipped blueprints. They should be ready within 6 hours after the full crawler cycle is done.